### PR TITLE
 Fix unnecessary handlers creation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,16 +47,18 @@ export const useArray = initial => {
   return {
     value,
     setValue,
-    add: useCallback(a => setValue(v => [...v, a])),
-    clear: useCallback(() => setValue(() => [])),
-    removeById: useCallback(id =>
-      setValue(arr => arr.filter(v => v && v.id !== id))
+    add: useCallback(a => setValue(v => [...v, a]), []),
+    clear: useCallback(() => setValue(() => []), []),
+    removeById: useCallback(
+      id => setValue(arr => arr.filter(v => v && v.id !== id)),
+      []
     ),
-    removeIndex: useCallback(index =>
-      setValue(v => {
+    removeIndex: useCallback(
+      index => setValue(v => {
         v.splice(index, 1);
         return v;
-      })
+      }),
+      []
     )
   };
 };
@@ -66,16 +68,16 @@ export const useBoolean = initial => {
   return {
     value,
     setValue,
-    toggle: useCallback(() => setValue(v => !v)),
-    setTrue: useCallback(() => setValue(true)),
-    setFalse: useCallback(() => setValue(false))
+    toggle: useCallback(() => setValue(v => !v), []),
+    setTrue: useCallback(() => setValue(true), []),
+    setFalse: useCallback(() => setValue(false), [])
   };
 };
 
 export const useInput = initial => {
   const isNumber = typeof initial === "number";
   const [value, setValue] = useState(initial);
-  const onChange = useCallback(e => setValue(e.target.value));
+  const onChange = useCallback(e => setValue(e.target.value), []);
 
   return {
     value,
@@ -84,7 +86,7 @@ export const useInput = initial => {
       value !== undefined &&
       value !== null &&
       (!isNumber ? value.trim && value.trim() !== "" : true),
-    clear: useCallback(() => setValue("")),
+    clear: useCallback(() => setValue(""), []),
     onChange,
     bindToInput: {
       onChange,
@@ -126,10 +128,13 @@ export const useLogger = (name, props) => {
 export const useSetState = initialValue => {
   const { value, setValue } = useStateful(initialValue);
   return {
-    setState: v => {
-      let newValue = { ...value, ...v };
-      return setValue(newValue);
-    },
+    setState: useCallback(
+      v => {
+        let newValue = { ...value, ...v };
+        return setValue(newValue);
+      },
+      []
+    ),
     state: value
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -14,29 +14,31 @@ export const useNumber = (initial, { upperLimit, lowerLimit, loop } = {}) => {
     value,
     setValue,
     increase: useCallback(() => {
-      const nextValue = value + 1;
-      setValue(
-        upperLimit !== undefined
+      setValue(value => {
+        const nextValue = value + 1;
+
+        return upperLimit !== undefined
           ? nextValue - 1 < upperLimit
             ? nextValue
             : loop === true
               ? initial
               : value
-          : nextValue
-      );
-    }),
+          : nextValue;
+      })
+    }, []),
     decrease: useCallback(() => {
-      const nextValue = value - 1;
-      setValue(
-        lowerLimit !== undefined
+      setValue(value => {
+        const nextValue = value - 1;
+
+        return lowerLimit !== undefined
           ? nextValue + 1 > lowerLimit
             ? nextValue
             : loop === true
               ? upperLimit
               : value
-          : nextValue
-      );
-    })
+          : nextValue;
+      })
+    }, [])
   };
 };
 


### PR DESCRIPTION
Hi!

Just want to note, that it looks like that we should use the `inputs` second argument in the `useCallback` hook, otherwise the function would not be memoized.

Here is an example of the 'unexpected' behavior with `Button` rerender: https://codesandbox.io/s/wnykwk2wk5 (just click an `increase` button for the Counter and check the console). You can also just to uncomment the 15th line to replace the `useNumber` with the fixed version.

And I think that it is an important case for the `hooks` like this library has, and it looks like it was meant by the `useCallback` usage 😊.

Unfortunately, I did not found the tests, but it seems that it works 😄 .

Thanks!