### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 9
-  - 8
+  - 'node'
+  - '10'
+  - '8'


### PR DESCRIPTION
Node.js 9 reached its EOL and we should tests against all LTS and stable releases.

See https://github.com/nodejs/Release/blob/master/README.md