### PR TITLE
ci: test on Linux, macOS and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
   - 9
   - 8
+os:
+  - windows
+  - linux
+  - osx


### PR DESCRIPTION
Travis CI has early Windows support. Let's test on all 3 supported platforms to make sure that nothing breaks on any of them.

https://blog.travis-ci.com/2018-10-11-windows-early-release