### PR TITLE
feat: add resetState to useSetState

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Set of a helpful hooks, for different specific to some primitives types state changing helpers.
 Has two APIs:
 - [First](#Example) and original from v1 is based on object destructuring e.g. `const { value, toggle } = useBoolean(false)` (Docs below)
-- [Second API](./README-ARRAY.md) (recommended [why?](./README-ARRAY.md#migration-from-object-to-array-based)) is based on more idiomatic to React hooks API, e.g. like `useState` with array destructuring 
+- [Second API](./README-ARRAY.md) (recommended [why?](./README-ARRAY.md#migration-from-object-to-array-based)) is based on more idiomatic to React hooks API, e.g. like `useState` with array destructuring
 `const [value, actions] = useBoolean(false)` [(Docs)](./README-ARRAY.md)
 
 
@@ -81,7 +81,7 @@ import useBoolean from 'react-hanger/useBoolean' // will import only this functi
 
 ### useStateful
 
-Just an alternative syntax to `useState`, because it doesn't need array destructuring.  
+Just an alternative syntax to `useState`, because it doesn't need array destructuring.
 It returns an object with `value` and a `setValue` method.
 
 ```jsx
@@ -171,10 +171,10 @@ Methods:
 - `removeIndex`
 - `removeById` - if array consists of objects with some specific `id` that you pass
 all of them will be removed
-- `move` - moves item from position to position shifting other elements. 
+- `move` - moves item from position to position shifting other elements.
 ```
     So if input is [1, 2, 3, 4, 5]
-    
+
     from  | to    | expected
     3     | 0     | [4, 1, 2, 3, 5]
     -1    | 0     | [5, 1, 2, 3, 4]
@@ -200,13 +200,15 @@ Actions:
 ### useSetState
 
 ```jsx
-const { state, setState } = useSetState({ loading: false });
+const { state, setState, resetState } = useSetState({ loading: false });
 setState({ loading: true, data: [1, 2, 3] });
+resetState()
 ```
 
 Methods:
 
 - `setState(value)` - will merge the `value` with the current `state` (like this.setState works in React)
+- `resetState()` - will reset the current `state` to the `value` which you pass to the `useSetState` hook
 
 Properties:
 
@@ -214,8 +216,8 @@ Properties:
 
 ### usePrevious
 
-Use it to get the previous value of a prop or a state value.  
-It's from the official [React Docs](https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state).  
+Use it to get the previous value of a prop or a state value.
+It's from the official [React Docs](https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state).
 It might come out of the box in the future.
 
 ```jsx
@@ -232,7 +234,7 @@ const Counter = () => {
 
 ## Migration from v1 to v2
 
-- Migration to array based API is a bit more complex but recommended (especially if you're using ESLint rules for hooks). 
+- Migration to array based API is a bit more complex but recommended (especially if you're using ESLint rules for hooks).
 Take a look at [this section](./README-ARRAY.md#migration-from-object-to-array-based) in array API docs.
 - All lifecycle helpers are removed. Please replace `useOnMount`, `useOnUnmount` and `useLifecycleHooks` with `useEffect`.
 This:
@@ -240,9 +242,9 @@ This:
 useOnMount(() => console.log("I'm mounted!"))
 useOnUnmount(() =>  console.log("I'm unmounted"))
 // OR
-useLifecycleHooks({ 
+useLifecycleHooks({
   onMount: () => console.log("I'm mounted!"),
-  onUnmount: () => console.log("I'm unmounted!") 
+  onUnmount: () => console.log("I'm unmounted!")
 })
 ```
 to:

--- a/src/array/index.test.ts
+++ b/src/array/index.test.ts
@@ -137,24 +137,49 @@ describe('useSetState array', () => {
       field3?: number;
     };
     const { result } = renderHook(() => useSetState<State>({ field: 1, field2: 2 }));
-    const [, actions] = result.current;
+    const [, setState] = result.current;
 
     expect(result.current[0]).toEqual({ field: 1, field2: 2 });
 
-    act(() => actions({ field: 2, field3: 3 }));
+    act(() => setState({ field: 2, field3: 3 }));
 
     expect(result.current[0]).toEqual({ field: 2, field2: 2, field3: 3 });
+  });
+  it('should reset state to initial value', () => {
+    type State = {
+      field: number;
+      field2: number;
+      field3?: number;
+    };
+    const { result } = renderHook(() => useSetState<State>({ field: 1, field2: 2 }));
+    const [, setState, resetState] = result.current;
+
+    expect(result.current[0]).toEqual({ field: 1, field2: 2 });
+
+    act(() => setState({ field: 2, field3: 3 }));
+
+    expect(result.current[0]).toEqual({ field: 2, field2: 2, field3: 3 });
+
+    act(() => resetState());
+
+    expect(result.current[0]).toEqual({ field: 1, field2: 2 });
   });
   describe('hooks optimizations', () => {
     it('should keep actions reference equality after value change', () => {
       // given
       const { result } = renderHook(() => useSetState({}));
-      const [, originalActionsReference] = result.current;
-      expect(result.current[1]).toBe(originalActionsReference);
+      const [, originalSetStateReference, originalResetStateReference] = result.current;
+      expect(result.current[1]).toBe(originalSetStateReference);
+      expect(result.current[2]).toBe(originalResetStateReference);
       // when
-      act(() => originalActionsReference([1]));
+      act(() => originalSetStateReference({ field: 1 }));
       // then
-      expect(originalActionsReference).toBe(result.current[1]);
+      expect(originalSetStateReference).toBe(result.current[1]);
+
+      // when
+      act(() => originalResetStateReference());
+      // then
+      expect(originalResetStateReference).toBe(result.current[2]);
     });
   });
 });

--- a/src/array/useSetState.ts
+++ b/src/array/useSetState.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SetStateAction, useCallback, useState } from 'react';
 
 export type UseSetStateAction<T extends object> = React.Dispatch<SetStateAction<Partial<T>>>;
-export type UseSetState<T extends object> = [T, UseSetStateAction<T>];
+export type UseSetState<T extends object> = [T, UseSetStateAction<T>, () => void];
 
 export function useSetState<T extends object>(initialValue: T): UseSetState<T> {
   const [value, setValue] = useState<T>(initialValue);
@@ -15,7 +15,9 @@ export function useSetState<T extends object>(initialValue: T): UseSetState<T> {
     },
     [setValue],
   );
-  return [value, setState];
+  const resetState = useCallback(() => setValue(initialValue), []);
+
+  return [value, setState, resetState];
 }
 
 export default useSetState;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -120,16 +120,40 @@ describe('useSetState', () => {
 
     expect(result.current.state).toEqual({ field: 2, field2: 2, field3: 3 });
   });
+  it('should reset state to initial state', () => {
+    type State = {
+      field: number;
+      field2: number;
+      field3?: number;
+    };
+    const { result } = renderHook(() => useSetState<State>({ field: 1, field2: 2 }));
+    const { setState, resetState } = result.current;
+
+    expect(result.current.state).toEqual({ field: 1, field2: 2 });
+
+    act(() => setState({ field: 2, field3: 3 }));
+
+    expect(result.current.state).toEqual({ field: 2, field2: 2, field3: 3 });
+
+    act(() => resetState());
+
+    expect(result.current.state).toEqual({ field: 1, field2: 2 });
+  });
   describe('hooks optimizations', () => {
     it('should keep actions reference equality after value change', () => {
       // given
       const { result } = renderHook(() => useSetState<{}>({}));
-      const { setState } = result.current;
+      const { setState, resetState } = result.current;
       expect(result.current.setState).toBe(setState);
       // when
       act(() => setState([1]));
       // then
       expect(setState).toBe(result.current.setState);
+
+      // when
+      act(() => resetState());
+      // then
+      expect(resetState).toBe(result.current.resetState);
     });
   });
 });

--- a/src/useSetState.ts
+++ b/src/useSetState.ts
@@ -6,16 +6,18 @@ export type UseSetStateAction<T extends object> = React.Dispatch<SetStateAction<
 export type UseSetState<T extends object> = {
   setState: UseSetStateAction<T>;
   state: T;
+  resetState: () => void;
 };
 
 export function useSetState<T extends object>(initialValue: T): UseSetState<T> {
-  const [value, setState] = useSetStateArray(initialValue);
+  const [state, setState, resetState] = useSetStateArray(initialValue);
   return useMemo(
     () => ({
       setState,
-      state: value,
+      resetState,
+      state,
     }),
-    [setState, value],
+    [setState, resetState, state],
   );
 }
 


### PR DESCRIPTION
A example usage is cleaning the inner state:

```ts
const state = useSetState<Record<string, string>>({})
const handleChange = (key: string, value: string) => state.setState({ [key]: value })
const handleReset =  state.resetState
```
We can't use the exisited API `setState` coz If we merge the empty object `{}`, we get a new state with the same iteral value, not an empty state `{}`.