### PR TITLE
fix: fix useNumber increase with loop

### DIFF
--- a/src/array/useNumber.ts
+++ b/src/array/useNumber.ts
@@ -52,7 +52,7 @@ export function useNumber(
         if (upperLimit !== undefined) {
           if (nextValue > upperLimit) {
             if (loop) {
-              return initial;
+              return lowerLimit;
             }
             return upperLimit;
           }
@@ -61,7 +61,7 @@ export function useNumber(
         return nextValue;
       });
     },
-    [initial, loop, step, upperLimit],
+    [lowerLimit, loop, step, upperLimit],
   );
   const actions = useMemo(
     () => ({


### PR DESCRIPTION
When initial value isn't the lowerLimit, it works unexpected.