### PR TITLE
fix non-working loop when lowerLimit equals 0

### DIFF
--- a/src/array/useNumber.ts
+++ b/src/array/useNumber.ts
@@ -51,9 +51,14 @@ export function useNumber(
 
         if (upperLimit !== undefined) {
           if (nextValue > upperLimit) {
-            if (loop && lowerLimit) {
-              return lowerLimit;
+            if (loop) {
+              if (lowerLimit !== undefined) {
+                return lowerLimit;
+              }
+
+              return initial;
             }
+
             return upperLimit;
           }
         }
@@ -61,7 +66,7 @@ export function useNumber(
         return nextValue;
       });
     },
-    [loop, step, upperLimit, lowerLimit],
+    [step, upperLimit, loop, lowerLimit, initial],
   );
   const actions = useMemo(
     () => ({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -132,7 +132,7 @@ describe('useNumber', () => {
   });
 
   describe('loop mode', () => {
-    it('should go to lowerLimit value after reaching upperLimit', () => {
+    it('should go to lowerLimit value after increase reaching upperLimit', () => {
       // given
       const { result } = renderHook(() => useNumber(4, { loop: true, upperLimit: 5, lowerLimit: 0 }));
       const { increase } = result.current;
@@ -142,7 +142,7 @@ describe('useNumber', () => {
       // then
       expect(result.current.value).toBe(0);
     });
-    it('should go to initial value if no lowerLimit presented after reaching upperLimit', () => {
+    it('should go to initial value if no lowerLimit presented after increase reaching upperLimit', () => {
       // given
       const { result } = renderHook(() => useNumber(4, { loop: true, upperLimit: 5 }));
       const { increase } = result.current;
@@ -152,7 +152,7 @@ describe('useNumber', () => {
       // then
       expect(result.current.value).toBe(4);
     });
-    it('should stay on upperLimit after reaching its value if loop equals false', () => {
+    it('should stay on upperLimit after increase reaching its value if loop equals false', () => {
       // given
       const { result } = renderHook(() => useNumber(4, { loop: false, upperLimit: 5 }));
       const { increase } = result.current;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -131,6 +131,39 @@ describe('useNumber', () => {
     expect(result.current.value).toBe(3);
   });
 
+  describe('loop mode', () => {
+    it('should go to lowerLimit value after reaching upperLimit', () => {
+      // given
+      const { result } = renderHook(() => useNumber(4, { loop: true, upperLimit: 5, lowerLimit: 0 }));
+      const { increase } = result.current;
+      // when
+      act(() => increase());
+      act(() => increase());
+      // then
+      expect(result.current.value).toBe(0);
+    });
+    it('should go to initial value if no lowerLimit presented after reaching upperLimit', () => {
+      // given
+      const { result } = renderHook(() => useNumber(4, { loop: true, upperLimit: 5 }));
+      const { increase } = result.current;
+      // when
+      act(() => increase());
+      act(() => increase());
+      // then
+      expect(result.current.value).toBe(4);
+    });
+    it('should stay on upperLimit after reaching its value if loop equals false', () => {
+      // given
+      const { result } = renderHook(() => useNumber(4, { loop: false, upperLimit: 5 }));
+      const { increase } = result.current;
+      // when
+      act(() => increase());
+      act(() => increase());
+      // then
+      expect(result.current.value).toBe(5);
+    });
+  });
+
   describe('hooks optimizations', () => {
     it('should keep actions reference equality after value change', () => {
       // given


### PR DESCRIPTION
### Summary

#### Problem

Loop stuck on upperLimit when loop:true  and lowerLimit presented but equals 0, expected behavior that it will go to lower limit when it's presented.
I believe it's a bug 🤔 

- Loop stuck on upperLimit when loop:true but no lower limit presented
I think it would be nice if we could extend it to go to start (initial ) value if  loop:true but lower limit not presented

you can test those cases here (wanted to record some gifs but something wrong with my gif recorder 😞 )
https://codesandbox.io/s/suspicious-bohr-m90pp7?file=/src/App.tsx

#### Solution

what was done in this PR:
- fix non-working loop when lowerLimit equals 0 
- when loop:true and lowerLimit not presented, loop goes to start (initial) value after reaching upperLimit value

let me know WDYT about it 😄 

P.S I'm a big fan of this library and always wanted to made something for it 😄 looks like it's my chance 😄
